### PR TITLE
task/internal: Add sudo to solve permission denied errors

### DIFF
--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -255,7 +255,7 @@ def check_ceph_data(ctx, config):
     """
     log.info('Checking for non-empty /var/lib/ceph...')
     processes = ctx.cluster.run(
-        args='test -z $(ls -A /var/lib/ceph)',
+        args='test -z $(sudo ls -A /var/lib/ceph)',
         wait=False,
     )
     failed = False


### PR DESCRIPTION
Add sudo to remove "Permission denied" errors as follow:
2020-02-26T23:13:52.368 INFO:teuthology.orchestra.run.plana004:> test -z $(ls -A /var/lib/ceph)
2020-02-26T23:13:52.371 INFO:teuthology.orchestra.run.plana007:> test -z $(ls -A /var/lib/ceph)
2020-02-26T23:13:52.425 INFO:teuthology.orchestra.run.plana004.stderr:ls: cannot open directory /var/lib/ceph: Permission denied
2020-02-26T23:13:52.464 INFO:teuthology.orchestra.run.plana007.stderr:ls: cannot open directory /var/lib/ceph: Permission denied

Signed-off-by: chuqifang <chuqifang@hisilicon.com>